### PR TITLE
Add a feature

### DIFF
--- a/com.redhat.eclipseide.jdtlsclient.feature/build.properties
+++ b/com.redhat.eclipseide.jdtlsclient.feature/build.properties
@@ -1,0 +1,1 @@
+bin.includes = feature.xml

--- a/com.redhat.eclipseide.jdtlsclient.feature/feature.xml
+++ b/com.redhat.eclipseide.jdtlsclient.feature/feature.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature
+      id="com.redhat.eclipseide.jdtlsclient.feature"
+      label="JDT-LS integration in Eclipse IDE"
+      version="0.1.0.qualifier"
+      provider-name="Red Hat, Inc.">
+
+   <description url="https://github.com/redhat-developer/eclipseide-jdtls/blob/main/README.md">
+      A client for JDT-LS to provide edition of .java files in the Eclipse IDE.
+   </description>
+
+   <copyright>
+      Copyright (c) 2023, Red Hat Inc. and others
+   </copyright>
+
+   <license url="https://github.com/redhat-developer/eclipseide-jdtls/blob/main/LICENSE.txt">
+      MIT License
+
+Copyright (c) 2023 - present, Red Hat Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+   </license>
+
+   <plugin
+         id="com.redhat.eclipseide.jdtlsclient"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.jdt.ls.core"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.lsp4e"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+</feature>

--- a/com.redhat.eclipseide.jdtlsclient.feature/pom.xml
+++ b/com.redhat.eclipseide.jdtlsclient.feature/pom.xml
@@ -1,0 +1,12 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>com.redhat.eclipseide.jdtlsclient</groupId>
+		<artifactId>eclipseide-jdtls-parent</artifactId>
+		<version>0.1.0-SNAPSHOT</version>
+	</parent>
+	<artifactId>com.redhat.eclipseide.jdtlsclient.feature</artifactId>
+	<packaging>eclipse-feature</packaging>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
 		<module>jdt-ls-fork</module>
 		<module>com.redhat.eclipseide.jdtlsclient</module>
 		<module>com.redhat.eclipseide.jdtlsclient.test</module>
+		<module>com.redhat.eclipseide.jdtlsclient.feature</module>
 		<module>repository</module>
 	</modules>
 	<build>


### PR DESCRIPTION
This allows to force the version of LSP4E and JDT-LS, until eclipseide-jdtls is compatible with latest deliveries of both.