### PR TITLE
Build and deploy nightly

### DIFF
--- a/.github/workflows/build-and-deploy-main.yml
+++ b/.github/workflows/build-and-deploy-main.yml
@@ -3,6 +3,9 @@ on:
     branches:
       - master
       - main
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    - cron:  '0 0 * * *'
 
 jobs:
   build:


### PR DESCRIPTION
In order to pick latest JDT LS even if there is no change in jdtls client itself.