### PR TITLE
Build against 2023-12 simrel

### DIFF
--- a/target-platform/jdt-ls-client.target
+++ b/target-platform/jdt-ls-client.target
@@ -7,9 +7,7 @@
 		<!-- Actually required by JDT-LS, but marked as optional,
 		# Workaround https://github.com/eclipse/eclipse.jdt.ls/issues/2429 -->
 		<unit id="org.eclipse.buildship.feature.group" version="0.0.0"/>
-		<!-- Explicit version to have different versions of LSP4J -->
-		<unit id="org.apache.commons.compress" version="1.22.0.v20221207-1049"/>
-		<repository location="http://download.eclipse.org/releases/2023-09/"/>
+		<repository location="http://download.eclipse.org/releases/2023-12/"/>
 	</location>
 	<!-- Actually required by JDT-LS, but marked as optional,
 	# Workaround https://github.com/eclipse/eclipse.jdt.ls/issues/2429 -->
@@ -36,7 +34,6 @@
 		<unit id="org.mockito.mockito-core" version="0.0.0"/>
 		<!-- transitive dep of LSP4J -->
 		<unit id="com.google.gson" version="2.10.1"/>
-		<unit id="org.mockito.mockito-core" version="0.0.0"/>
 		<repository location="https://download.eclipse.org/eclipse/updates/4.30-I-builds/"/>
 	</location>
 	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">


### PR DESCRIPTION
As it's already using Platform 4.30 it makes sent to use latest simrel too.