### PR TITLE
Update java grammar, including the addition of textblocks and fixes for the 'throws' and 'new' keywords

### DIFF
--- a/com.redhat.eclipseide.jdtlsclient/grammars/java.tmLanguage.json
+++ b/com.redhat.eclipseide.jdtlsclient/grammars/java.tmLanguage.json
@@ -1,10 +1,8 @@
 {
 	"information_for_contributors": [
-		"This file has been converted from https://github.com/atom/language-java/blob/master/grammars/java.cson",
-		"If you want to provide a fix or improvement, please create a pull request against the original repository.",
-		"Once accepted there, we are happy to receive an update request."
+		"This file has been copied from https://github.com/microsoft/vscode/blob/b37252c18238fffcebdc9fd7680f1dabea3a50a0/extensions/java/syntaxes/java.tmLanguage.json",
+		"The source location lists https://github.com/atom/language-java/blob/29f977dc42a7e2568b39bb6fb34c4ef108eb59b3/LICENSE.md as the original repository. It is therefore licensed under MIT."
 	],
-	"version": "https://github.com/atom/language-java/commit/29f977dc42a7e2568b39bb6fb34c4ef108eb59b3",
 	"name": "Java",
 	"scopeName": "source.java",
 	"patterns": [
@@ -1379,6 +1377,17 @@
 		"properties": {
 			"patterns": [
 				{
+					"match": "(\\.)\\s*(new)",
+					"captures": {
+						"1": {
+							"name": "punctuation.separator.period.java"
+						},
+						"2": {
+							"name": "keyword.control.new.java"
+						}
+					}
+				},
+				{
 					"match": "(\\.)\\s*([a-zA-Z_$][\\w$]*)(?=\\s*\\.\\s*[a-zA-Z_$][\\w$]*)",
 					"captures": {
 						"1": {
@@ -1572,6 +1581,27 @@
 		"strings": {
 			"patterns": [
 				{
+					"begin": "\"\"\"",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.definition.string.begin.java"
+						}
+					},
+					"end": "\"\"\"",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.definition.string.end.java"
+						}
+					},
+					"name": "string.quoted.triple.java",
+					"patterns": [
+						{
+							"match": "(\\\\\"\"\")(?!\")|(\\\\.)",
+							"name": "constant.character.escape.java"
+						}
+					]
+				},
+				{
 					"begin": "\"",
 					"beginCaptures": {
 						"0": {
@@ -1632,6 +1662,9 @@
 				{
 					"match": "[a-zA-Z$_][\\.a-zA-Z0-9$_]*",
 					"name": "storage.type.java"
+				},
+				{
+					"include": "#comments"
 				}
 			]
 		},


### PR DESCRIPTION
Updating based on [language-support/java/java.tmLanguage.json](https://github.com/redhat-developer/vscode-java/blob/7ef38c61b2351dee4cda0811b0c0f26f965a59f8/language-support/java/java.tmLanguage.json). The grammar is now owned there as per discussion at https://github.com/microsoft/vscode/pull/187725#issuecomment-1643685076.

The following changes are included:
- Added support for text blocks / triple quotes (redhat-developer/vscode-java#3200  + redhat-developer/vscode-java#3412)
- Corrected comments after 'throws' keyword (redhat-developer/vscode-java#3209)
- Fixed highlighting for 'new' keyword for inner classes (redhat-developer/vscode-java#3224)

