### PR TITLE
Update to new setup-maven gh action

### DIFF
--- a/.github/workflows/build-and-deploy-main.yml
+++ b/.github/workflows/build-and-deploy-main.yml
@@ -26,7 +26,7 @@ jobs:
         java-version: 21
         distribution: 'temurin'
     - name: Set up Maven
-      uses: stCarolas/setup-maven@v4.5
+      uses: stCarolas/setup-maven@v5
       with:
         maven-version: 3.9.6
     - name: Build with Maven 🏗️

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -20,7 +20,7 @@ jobs:
         java-version: 21
         distribution: 'temurin'
     - name: Set up Maven
-      uses: stCarolas/setup-maven@v4.5
+      uses: stCarolas/setup-maven@v5
       with:
         maven-version: 3.9.6
     - name: Set up Display 📺


### PR DESCRIPTION
Fixes: Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: stCarolas/setup-maven@v4.5. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.